### PR TITLE
Adding the capacity to JSONParsers to treat {count: n, items : []} objects as arrays.

### DIFF
--- a/src/main/java/fi/foyt/foursquare/api/JSONFieldParser.java
+++ b/src/main/java/fi/foyt/foursquare/api/JSONFieldParser.java
@@ -159,19 +159,19 @@ public class JSONFieldParser {
    */
   private static Object parseValue(Class<?> clazz, JSONObject jsonObject, String objectFieldName, boolean skipNonExistingFields) throws JSONException, FoursquareApiException {
     if (clazz.isArray()) {
-    	Object value = jsonObject.get(objectFieldName);
-    	JSONArray jsonArray;
-    	if(value instanceof JSONArray) {
-	      jsonArray = (JSONArray)value;
-    	}
-    	else {
-    		if((value instanceof JSONObject) && (((JSONObject)value).has("items"))) {
-    			jsonArray = ((JSONObject)value).getJSONArray("items");
-    		}
-    		else {
-    			throw new FoursquareApiException("JSONObject[\"" + objectFieldName + "\"] is neither a JSONArray nor a {count, items} object.");
-    		}
-    	}
+	  Object value = jsonObject.get(objectFieldName);
+	  
+	  JSONArray jsonArray;
+	  if(value instanceof JSONArray) {
+        jsonArray = (JSONArray)value;
+	  } else {
+	    if((value instanceof JSONObject) && (((JSONObject)value).has("items"))) {
+	      jsonArray = ((JSONObject)value).getJSONArray("items");
+	    }
+	    else {
+	      throw new FoursquareApiException("JSONObject[\"" + objectFieldName + "\"] is neither a JSONArray nor a {count, items} object.");
+	    }
+	  }
 
       Class<?> arrayClass = clazz.getComponentType();
       Object[] arrayValue = (Object[]) Array.newInstance(arrayClass, jsonArray.length());


### PR DESCRIPTION
Today, the Basic Examples fail to retrieve some venues due to a change in the API response after 20120121.

I'm not sure this is the good way to do it but it does just very few changes and should work very well reading the data. I'm not sure there is somewhere in the code where one write a CompleteVenue into JSON for example. I don't see this. In this case there will be a problem but in such a case, we have to add some test to the suite.

To do the example work, one have to call setVersion after FoursquareApi creation because, at this time, the default version is no longer supported.
