### PR TITLE
Foursquare default version deprecated and giving a 410 error on a few userless requests

### DIFF
--- a/src/main/java/fi/foyt/foursquare/api/FoursquareApi.java
+++ b/src/main/java/fi/foyt/foursquare/api/FoursquareApi.java
@@ -10,57 +10,19 @@
  */
 package fi.foyt.foursquare.api;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import fi.foyt.foursquare.api.entities.*;
+import fi.foyt.foursquare.api.entities.notifications.Notification;
+import fi.foyt.foursquare.api.io.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import fi.foyt.foursquare.api.entities.Badge;
-import fi.foyt.foursquare.api.entities.BadgeSets;
-import fi.foyt.foursquare.api.entities.Badges;
-import fi.foyt.foursquare.api.entities.Category;
-import fi.foyt.foursquare.api.entities.Checkin;
-import fi.foyt.foursquare.api.entities.CheckinGroup;
-import fi.foyt.foursquare.api.entities.Comment;
-import fi.foyt.foursquare.api.entities.CompactUser;
-import fi.foyt.foursquare.api.entities.CompactVenue;
-import fi.foyt.foursquare.api.entities.CompleteSpecial;
-import fi.foyt.foursquare.api.entities.CompleteTip;
-import fi.foyt.foursquare.api.entities.CompleteUser;
-import fi.foyt.foursquare.api.entities.CompleteVenue;
-import fi.foyt.foursquare.api.entities.GeoCode;
-import fi.foyt.foursquare.api.entities.KeywordGroup;
-import fi.foyt.foursquare.api.entities.LeaderboardItemGroup;
-import fi.foyt.foursquare.api.entities.LinkGroup;
-import fi.foyt.foursquare.api.entities.MiniVenue;
-import fi.foyt.foursquare.api.entities.Photo;
-import fi.foyt.foursquare.api.entities.PhotoGroup;
-import fi.foyt.foursquare.api.entities.RecommendationGroup;
-import fi.foyt.foursquare.api.entities.Recommended;
-import fi.foyt.foursquare.api.entities.Setting;
-import fi.foyt.foursquare.api.entities.SpecialGroup;
-import fi.foyt.foursquare.api.entities.TipGroup;
-import fi.foyt.foursquare.api.entities.Todo;
-import fi.foyt.foursquare.api.entities.TodoGroup;
-import fi.foyt.foursquare.api.entities.UserGroup;
-import fi.foyt.foursquare.api.entities.VenueGroup;
-import fi.foyt.foursquare.api.entities.VenueHistoryGroup;
-import fi.foyt.foursquare.api.entities.VenuesAutocompleteResult;
-import fi.foyt.foursquare.api.entities.VenuesSearchResult;
-import fi.foyt.foursquare.api.entities.Warning;
-import fi.foyt.foursquare.api.entities.notifications.Notification;
-import fi.foyt.foursquare.api.io.DefaultIOHandler;
-import fi.foyt.foursquare.api.io.IOHandler;
-import fi.foyt.foursquare.api.io.Method;
-import fi.foyt.foursquare.api.io.MultipartParameter;
-import fi.foyt.foursquare.api.io.Response;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Entry point for FoursquareAPI.
@@ -69,7 +31,7 @@ import fi.foyt.foursquare.api.io.Response;
  */
 public class FoursquareApi {
 
-  private static final String DEFAULT_VERSION = "20110615";
+  private static final String DEFAULT_VERSION = "20140806";
 
   /**
    * Constructor.


### PR DESCRIPTION
Hi John Cline,

It seems like Foursquare has deprecated the v=20110615 parameter defined on FoursquareApi.DEFAULT_VERSION. 

The weird part about this is because there are a few requests you can make using its last value without any error ( As in fi.foyt.foursquare.api.tests.Venues methods ) but for some userless requests it was giving the following error:

```
Error occured: 
  code: 410
  type: param_error
  detail: The Foursquare API no longer supports requests that pass in a version v <= 20120609
```

I figured out a example of a situation where it raises the error as shown below:

```
public static void main(String[] args) throws FoursquareApiException {
    FoursquareApi foursquareApi = new FoursquareApi("BKWGJHTTXOVZUACQ3T0FSY5MTCEEQRMISZ10FPQUHITT2K2I", "WCKR1DIW3NE4CKIR41TCJA2KCGXE43GRUWBS0EOBTCBD2OTJ", null);

    Result<VenuesSearchResult> result = foursquareApi.venuesSearch(String.format("%f,%f", -23.557197, -46.747266), null, null, null, null, null, null, null, null, null, null,null,null);

    if (result.getMeta().getCode() == 200) {
        for (CompactVenue compactVenue : result.getResult().getVenues()) {
            System.out.println("Name: " + compactVenue.getName());
            System.out.println("Category: " + categoryResult(compactVenue.getCategories()));
        }
    } else {
        System.out.println("Error occured: ");
        System.out.println("  code: " + result.getMeta().getCode());
        System.out.println("  type: " + result.getMeta().getErrorType());
        System.out.println("  detail: " + result.getMeta().getErrorDetail());

    }
}

public static String categoryResult(Category[] categories) {
    String result = "";
    for (Category c : categories) {
        result += c.getName() + ",";
    }
    return result;
}
```

Actually by just changing DEFAULT_VERSION to "20140806" it fixes that problem and keep all JUnit tests working as well. 

Best Regards
