### PR TITLE
making FoursquareApi CDI compatible

### DIFF
--- a/src/main/java/fi/foyt/foursquare/api/FoursquareApi.java
+++ b/src/main/java/fi/foyt/foursquare/api/FoursquareApi.java
@@ -78,7 +78,8 @@ public class FoursquareApi {
    * CDI eyes only
    * @deprecated CDI eyes only
    */
-  public FoursquareApi() {}
+  public FoursquareApi() {
+  }
 
   /**
    * Constructor.

--- a/src/main/java/fi/foyt/foursquare/api/FoursquareApi.java
+++ b/src/main/java/fi/foyt/foursquare/api/FoursquareApi.java
@@ -75,6 +75,12 @@ public class FoursquareApi {
   private static final String DEFAULT_VERSION = "20140131";
 
   /**
+   * CDI eyes only
+   * @deprecated CDI eyes only
+   */
+  public FoursquareApi() {}
+
+  /**
    * Constructor.
    *
    * @param clientId Foursquare Client id


### PR DESCRIPTION
CDI spec requires a default non-private constructor to being able to manage it.

I'm adding the default constructor and marking it as deprecated to make explicit that it only should be used by CDI engine.